### PR TITLE
Fix bug where gifs from Giphy don't show up properly

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -10,7 +10,7 @@
     <meta http-equiv="Content-Security-Policy" content="
       default-src 'self';
       font-src 'self' fonts.gstatic.com;
-      img-src 'self' data: live.staticflickr.com i.imgur.com referrer.disqus.com c.disquscdn.com;
+      img-src 'self' data: live.staticflickr.com i.imgur.com media.giphy.com referrer.disqus.com c.disquscdn.com;
       script-src 'self' {{ site.disqus.shortname }}.disqus.com www.google.com www.gstatic.com;
       prefetch-src disqus.com c.disquscdn.com;
       frame-src 'self' referrer.disqus.com disqus.com www.google.com docs.google.com;

--- a/assets/css/_navigation.scss
+++ b/assets/css/_navigation.scss
@@ -38,3 +38,9 @@ nav.navbar {
   margin-top: 1px;
   margin-bottom: 1px;
 }
+
+@media (max-width: 768px) {
+  .navbar-collapse {
+    padding-bottom: 0.6rem;
+  }
+}


### PR DESCRIPTION
## Changes

* Allow gifs from Giphy in the website's CSP
* When the navigation bar has the expand/collapse button (aka on mobile/small tablet screens), then add a little bit of extra space to the bottom of the list of items when expanded (do this so that there's just a little bit more space between the last item and the bottom of the expanded navigation bar)

## Related Pull Requests and Issues

* https://github.com/emmahsax/emmahsax.github.io/pull/366

## Additional Context

> Add any other context about the problem here.

## PR Scheduler

> If you'd like to use the PR Scheduler, then add a comment to this pull request where the date/time is written in UTC and the pull request will merged and deployed at the date/time provided. The comment should look like this:
>
> ```
> # example (May 18, 2020 at 17:58 UTC):
> @prscheduler 2020-05-18 17:58
>
> @prscheduler YYYY-MM-DD HH:MM
> ```
