### PR TITLE
Add Rubocop back

### DIFF
--- a/.github/contributing.md
+++ b/.github/contributing.md
@@ -6,6 +6,7 @@
 * [Running Locally](#running-locally)
 * [HTML Proofer](#html-proofer)
 * [Markdown Linter](#markdown-linter)
+* [Rubocop](#rubocop)
 * [Javascript Linter](#javascript-linter)
 * [Continuous Integration](#continuous-integration)
   * [Tests](#tests)
@@ -92,7 +93,17 @@ bin/markdown_linter.sh
 
 Note that the linter specifically passes in directories and files to evaluate, so if you create any new Markdown files, you'll have to add them to `bin/markdown_linter.sh`.
 
-GitHub Actions also runs the same `bin/markdown_linter.sh` script on each test run. We set it to `continue-on-error` though, so developers should make it a habit to check out its results every so often.
+GitHub Actions also runs the same `bin/markdown_linter.sh` script on each test run.
+
+## Rubocop
+
+This project uses [Rubocop](https://github.com/rubocop-hq/rubocop) to check its Ruby files. To run Rubocop locally, run:
+
+```bash
+bundle exec rubocop
+```
+
+GitHub Actions also runs Rubocop on each test run.
 
 ## Javascript Linter
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,7 +46,9 @@ jobs:
 
     - name: Markdown Linter
       run: bin/markdown_linter.sh
-      continue-on-error: true
+
+    - name: Rubocop
+      run: bundle exec rubocop
 
     - name: Javascript Linter
       run: npm install standard --save-dev && bin/javascript_linter.sh

--- a/Gemfile
+++ b/Gemfile
@@ -23,4 +23,5 @@ gem 'webrick'
 group :test, :development do
   gem 'html-proofer'
   gem 'mdl'
+  gem 'rubocop'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -37,6 +37,7 @@ GEM
       zeitwerk (~> 2.3)
     addressable (2.7.0)
       public_suffix (>= 2.0.2, < 5.0)
+    ast (2.4.2)
     chef-utils (16.10.8)
     colorator (1.1.0)
     commonmarker (0.21.2)
@@ -137,6 +138,8 @@ GEM
     nokogumbo (2.0.4)
       nokogiri (~> 1.8, >= 1.8.4)
     parallel (1.20.1)
+    parser (3.0.0.0)
+      ast (~> 2.4.1)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
     posix-spawn (0.3.15)
@@ -146,10 +149,23 @@ GEM
     rb-fsevent (0.10.4)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
+    regexp_parser (2.1.1)
     rexml (3.2.4)
     rouge (3.26.0)
+    rubocop (1.10.0)
+      parallel (~> 1.10)
+      parser (>= 3.0.0.0)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.8, < 3.0)
+      rexml
+      rubocop-ast (>= 1.2.0, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 3.0)
+    rubocop-ast (1.4.1)
+      parser (>= 2.7.1.5)
     ruby-enum (0.9.0)
       i18n
+    ruby-progressbar (1.11.0)
     safe_yaml (1.0.5)
     sassc (2.4.0)
       ffi (~> 1.9)
@@ -186,6 +202,7 @@ DEPENDENCIES
   jekyll-time-to-read
   jekyll-titles-from-headings
   mdl
+  rubocop
   webrick
 
 BUNDLED WITH


### PR DESCRIPTION
## Changes

Add Rubocop back in as a Ruby linter to test the format of all of the Ruby files in this project (even though there's not many Ruby files right now). Rubocop should run as part of the GitHub Actions `test` job on all PR pipelines.

https://github.com/emmahsax/emmahsax.github.io/pull/376 is the PR where I removed Rubocop, but I've since changed my mind and want Rubocop back here.

## Related Pull Requests and Issues

* https://github.com/emmahsax/emmahsax.github.io/pull/376

## For QA

- [ ] All tests should pass on this PR

## PR Scheduler

> If you'd like to use the PR Scheduler, then add a comment to this pull request where the date/time is written in UTC and the pull request will merged and deployed at the date/time provided. The comment should look like this:
>
> ```
> # example (May 18, 2020 at 17:58 UTC):
> @prscheduler 2020-05-18 17:58
>
> @prscheduler YYYY-MM-DD HH:MM
> ```
