### PR TITLE
Adjust the bottom border color of tables

### DIFF
--- a/assets/css/_table.scss
+++ b/assets/css/_table.scss
@@ -7,6 +7,5 @@ tr {
   display: table-row;
   vertical-align: inherit;
   border-color: inherit;
-  border-bottom: solid 0.0625rem;
-  border-color: #4c656a;
+  border-bottom: solid 0.0625rem #dee2e6;
 }


### PR DESCRIPTION
## Changes

Make the bottom border color of the tables the same color as the rest of the borders:

![image](https://user-images.githubusercontent.com/7562793/115723909-12009b80-a346-11eb-9e1f-a4caa8e06b55.png)

## Related Pull Requests and Issues

> If applicable, a list of related pull requests and issues:
>
> * Issue URL link
> * Pull Request URL link

## Additional Context

> Add any other context about the problem here.

## PR Scheduler

> If you'd like to use the PR Scheduler, then add a comment to this pull request where the date/time is written in UTC and the pull request will merged and deployed at the date/time provided. The comment should look like this:
>
> ```
> # example (May 18, 2020 at 17:58 UTC):
> @prscheduler 2020-05-18 17:58
>
> @prscheduler YYYY-MM-DD HH:MM
> ```
