### PR TITLE
Fix captioning and PhotoSwipe bugs

### DIFF
--- a/.github/contributing.md
+++ b/.github/contributing.md
@@ -379,6 +379,7 @@ Using Lightbox2 in order to make photos clickable is also an option, but this is
 </details>
 
 NOTES:
+
 * If a `caption` is given, but not an `alt`, then the `caption` is used as both a caption and an alt. If an `alt` is given, but no `caption`, then there is no caption present on the photo. And if nothing is given, then there's neither a caption nor an alt on the photo.
 * The `full_width` and `full_height` represent the pixel sizes of the original image. If neither a `thumb_width` or a `thumb_height` is provided, then the thumb photo will be the same size as the original photo. If both a `thumb_width` and `thumb_height` are provided, then the image will warp to fit both parameters.
 

--- a/.github/contributing.md
+++ b/.github/contributing.md
@@ -356,7 +356,8 @@ Alternatively, to use PhotoSwipe to make the photo clickable, and then it'll zoo
 <div class="photoswipe-gallery">
   {% include elements/photo.html
       url="/assets/images/picture-01.jpg"
-      thumb_width="200" caption="Caption will show when the photo is enlarged" alt="Alt shows if the photo cannot be shown"
+      thumb_width="200" thumb_height="230
+      caption="Caption will show when the photo is enlarged" alt="Alt shows if the photo cannot be shown"
       full_width="400" full_height="200"
   %}
 </div>
@@ -369,14 +370,17 @@ Using Lightbox2 in order to make photos clickable is also an option, but this is
 ```html
 {% include elements/photo.html
     url="/assets/images/picture-01.jpg"
-    thumb_width="200" caption="Caption will show when the photo is enlarged" alt="Alt shows if the photo cannot be shown"
+    thumb_width="200" thumb_height="230
+    caption="Caption will show when the photo is enlarged" alt="Alt shows if the photo cannot be shown"
     lightbox_gallery="Lightbox Gallery Name" type="lightbox2"
 %}
 ```
 
 </details>
 
-NOTE: If a `caption` is given, but not an `alt`, then the `caption` is used as both a caption and an alt. If an `alt` is given, but no `caption`, then there is no caption present on the photo. And if nothing is given, then there's neither a caption nor an alt on the photo.
+NOTES:
+* If a `caption` is given, but not an `alt`, then the `caption` is used as both a caption and an alt. If an `alt` is given, but no `caption`, then there is no caption present on the photo. And if nothing is given, then there's neither a caption nor an alt on the photo.
+* The `full_width` and `full_height` represent the pixel sizes of the original image. If neither a `thumb_width` or a `thumb_height` is provided, then the thumb photo will be the same size as the original photo. If both a `thumb_width` and `thumb_height` are provided, then the image will warp to fit both parameters.
 
 The `resources/` directory gives me a place to keep PDF documents that are linked in this site. You can put a link to it in Markdown:
 

--- a/_blog_posts/adding-html-forms-to-static-sites.md
+++ b/_blog_posts/adding-html-forms-to-static-sites.md
@@ -95,12 +95,12 @@ Here is a picture of what the form now looks like:
 <div class="text-center photoswipe-gallery">
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50910867482_e25fc606ba_b.jpg"
-      thumb_width="400" caption="A basic HTML form"
+      caption="A basic HTML form"
       full_width="975" full_height="437"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50910770391_a88fce2728_c.jpg"
-      thumb_width="400" caption="The 'thank you' that is shown upon submission"
+      thumb_height="150" caption="The 'thank you' that is shown upon submission"
       full_width="795" full_height="262"
   %}
 </div>

--- a/_blog_posts/adding-html-forms-to-static-sites.md
+++ b/_blog_posts/adding-html-forms-to-static-sites.md
@@ -95,7 +95,7 @@ Here is a picture of what the form now looks like:
 <div class="text-center photoswipe-gallery">
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50910867482_e25fc606ba_b.jpg"
-      caption="A basic HTML form"
+      thumb_height="150" caption="A basic HTML form"
       full_width="975" full_height="437"
   %}
   {% include elements/photo.html

--- a/_blog_posts/welcome-to-kenya/the-cuisine-and-the-lodging.md
+++ b/_blog_posts/welcome-to-kenya/the-cuisine-and-the-lodging.md
@@ -52,12 +52,12 @@ The rooms are small, but that's by design. They feel cozy and snug. The hallways
 <div class="text-center photoswipe-gallery">
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/48797244476_b8b7e63c5d_o.jpg"
-      thumb_width="450" caption="The Ark lodging"
+      thumb_height="230" caption="The Ark lodging"
       full_width="960" full_height="720"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/48826445088_4fcce75760_o.jpg"
-      thumb_width="250" caption="The Ark's buffet line"
+      thumb_height="230" caption="The Ark's buffet line"
       full_width="3024" full_height="4032"
   %}
 </div>
@@ -83,12 +83,12 @@ I don't have many pictures of the exterior of Sarova Shaba Game Lodge, and that'
 <div class="text-center photoswipe-gallery">
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/48872057586_638b72d2ca_o.jpg"
-      thumb_width="400" caption="Sarova Shaba pool"
+      thumb_height="230" caption="Sarova Shaba pool"
       full_width="960" full_height="720"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/48826445063_35a542e32e_o.jpg"
-      thumb_width="400" caption="Sarova Shaba Room"
+      thumb_height="230" caption="Sarova Shaba Room"
       full_width="4032" full_height="3024"
   %}
 </div>
@@ -106,27 +106,27 @@ Women and mothers take care of the children, take care of the livestock, do bead
 <div class="text-center photoswipe-gallery">
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/48799101398_ac4b7ba7c5_o.jpg"
-      thumb_width="400" caption="Samburu village"
+      thumb_height="230" caption="Samburu village"
       full_width="4032" full_height="3024"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/48799451886_c952b2af60_o.jpg"
-      thumb_width="450" caption="Samburu children"
+      thumb_height="230" caption="Samburu children"
       full_width="6000" full_height="4000"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/48826820661_e3168ba066_o.png"
-      thumb_width="550" caption="Samburu village"
+      thumb_height="230" caption="Samburu village"
       full_width="2208" full_height="1242"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/48826444963_7102bf89d2_o.jpg"
-      thumb_width="400" caption="Samburu hut"
+      thumb_height="230" caption="Samburu hut"
       full_width="4032" full_height="3024"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/48826445033_8dc2101822_o.jpg"
-      thumb_width="400" caption="Samburu elders"
+      thumb_height="230" caption="Samburu elders"
       full_width="4032" full_height="3024"
   %}
 </div>
@@ -138,12 +138,12 @@ Ol Pejeta's Sweetwaters Serena Camp was my favorite place we stayed. It's a tent
 <div class="text-center photoswipe-gallery">
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/48796885958_e5f240a3e4_o.jpg"
-      thumb_width="200" caption="Sweetwaters lodging"
+      thumb_height="230" caption="Sweetwaters lodging"
       full_width="720" full_height="960"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/48872252992_5a8b9aea8d_o.jpg"
-      thumb_width="400" caption="Sweetwaters tent"
+      thumb_height="230" caption="Sweetwaters tent"
       full_width="960" full_height="640"
   %}
 </div>
@@ -185,17 +185,17 @@ However, if you're lucky, your cabin windows (or deck on a top floor), gives you
 <div class="text-center photoswipe-gallery">
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/48796885438_3c889d5496_o.jpg"
-      thumb_width="170" caption="Sopa lodging"
+      thumb_height="230" caption="Sopa lodging"
       full_width="720" full_height="960"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/48797382142_5ed4a79360_o.jpg"
-      thumb_width="300" caption="Sopa room with couch to watch the hippos"
+      thumb_height="230" caption="Sopa room with couch to watch the hippos"
       full_width="960" full_height="720"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/48826444793_daf66a4e6d_o.jpg"
-      thumb_width="300" caption="Sopa lodging building"
+      thumb_height="230" caption="Sopa lodging building"
       full_width="4032" full_height="3024"
   %}
 </div>
@@ -217,7 +217,7 @@ Oh, the last thing I'll mention about Fig Tree Camp: they had limited times the 
 <div class="text-center photoswipe-gallery">
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/48826443083_3125e40674_o.jpg"
-      thumb_width="400" caption="Maasai Mara room"
+      thumb_height="230" caption="Maasai Mara room"
       full_width="3024" full_height="4032"
   %}
 </div>
@@ -237,17 +237,17 @@ The last thing I'll mention is that both tribes do a type of ceremonial activity
 <div class="text-center photoswipe-gallery">
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/48799594437_12567ee4f7_o.jpg"
-      thumb_width="250" caption="Maasai Mara jumping ceremony"
+      thumb_height="230" caption="Maasai Mara jumping ceremony"
       full_width="2988" full_height="5312"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/48799451771_dfeae19ebe_o.jpg"
-      thumb_width="315" caption="Maasai Mara man and child"
+      thumb_height="230" caption="Maasai Mara man and child"
       full_width="1400" full_height="1965"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/48799595727_faf4d27004_o.jpg"
-      thumb_width="500" caption="Maasai Mara village"
+      thumb_height="230" caption="Maasai Mara village"
       full_width="900" full_height="675"
   %}
 </div>

--- a/_blog_posts/welcome-to-kenya/the-game-drives.md
+++ b/_blog_posts/welcome-to-kenya/the-game-drives.md
@@ -81,42 +81,42 @@ Samburu is an area north of the equator, located in the center of Kenya. The lan
 <div class="text-center photoswipe-gallery">
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/48740606393_4f24904b75_o.jpg"
-      thumb_width="200" caption="Baboons at Samburu"
+      thumb_height="230" caption="Baboons at Samburu"
       full_width="600" full_height="450"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/48740606453_02c1dcf73c_o.jpg"
-      thumb_width="200" caption="Elephant at Samburu"
+      thumb_height="230" caption="Elephant at Samburu"
       full_width="600" full_height="450"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/48741119692_f8d37d4a98_o.jpg"
-      thumb_width="200" caption="Oryx at Samburu"
+      thumb_height="230" caption="Oryx at Samburu"
       full_width="600" full_height="450"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/48740935066_7e21df8970_o.jpg"
-      thumb_width="200" caption="Reticulated giraffes at Samburu"
+      thumb_height="230" caption="Reticulated giraffes at Samburu"
       full_width="600" full_height="450"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/48740606638_752252d3bd_o.jpg"
-      thumb_width="200" caption="Impala at Samburu"
+      thumb_height="230" caption="Impala at Samburu"
       full_width="600" full_height="450"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/48740606678_6d9f3482a6_o.jpg"
-      thumb_width="170" caption="Lioness at Samburu"
+      thumb_height="230" caption="Lioness at Samburu"
       full_width="600" full_height="536"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/48741119697_5b99e26766_o.jpg"
-      thumb_width="200" caption="Ostrich at Samburu"
+      thumb_height="230" caption="Ostrich at Samburu"
       full_width="600" full_height="450"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/48741119832_225ebe076d_o.jpg"
-      thumb_width="200" caption="Zebras at Samburu"
+      thumb_height="230" caption="Zebras at Samburu"
       full_width="600" full_height="450"
   %}
 </div>
@@ -132,17 +132,17 @@ We managed to visit the Chimpanzee and Rhinoceros conservancies while we were th
 <div class="text-center photoswipe-gallery">
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/48741119427_950e08953a_o.jpg"
-      thumb_width="300" caption="Chimpanzee at Ol Pejeta"
+      thumb_height="230" caption="Chimpanzee at Ol Pejeta"
       full_width="600" full_height="400"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/48741119722_6ea09cfa61_o.jpg"
-      thumb_width="270" caption="Rhino at Ol Pejeta... and we got to pet it!"
+      thumb_height="230" caption="Rhino at Ol Pejeta... and we got to pet it!"
       full_width="600" full_height="450"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/48740606828_4cca69618e_o.jpg"
-      thumb_width="150" caption="Rhino feeding at Ol Pejeta"
+      thumb_height="230" caption="Rhino feeding at Ol Pejeta"
       full_width="450" full_height="600"
   %}
 </div>
@@ -178,77 +178,77 @@ Although I wish I could attach all of the pictures we have from the Maasai Mara,
 <div class="text-center photoswipe-gallery">
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/48740934961_f96f3dd557_o.jpg"
-      thumb_width="215" caption="Cheetah at Maasai Mara"
+      thumb_height="230" caption="Cheetah at Maasai Mara"
       full_width="600" full_height="414"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/48740935001_ed2ef1a21f_o.jpg"
-      thumb_width="200" caption="Elephants at Maasai Mara"
+      thumb_height="230" caption="Elephants at Maasai Mara"
       full_width="600" full_height="450"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/48741119482_2a65f2332a_o.jpg"
-      thumb_width="225" caption="Momma elephant with baby at Maasai Mara"
+      thumb_height="230" caption="Momma elephant with baby at Maasai Mara"
       full_width="600" full_height="400"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/48741119542_20ff32c710_o.jpg"
-      thumb_width="200" caption="Giraffe at Maasai Mara"
+      thumb_height="230" caption="Giraffe at Maasai Mara"
       full_width="600" full_height="450"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/48741119572_75b99d2f3e_o.jpg"
-      thumb_width="200" caption="Giraffe headshot at Maasai Mara"
+      thumb_height="230" caption="Giraffe headshot at Maasai Mara"
       full_width="600" full_height="450"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/48740935081_640dc843a8_o.jpg"
-      thumb_width="225" caption="Hippo at Maasai Mara"
+      thumb_height="230" caption="Hippo at Maasai Mara"
       full_width="600" full_height="400"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/48740935106_67389659e4_o.jpg"
-      thumb_width="200" caption="Swimming hippo at Maasai Mara"
+      thumb_height="230" caption="Swimming hippo at Maasai Mara"
       full_width="600" full_height="450"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/48741119617_67389659e4_o.jpg"
-      thumb_width="200" caption="Hyenas at Maasai Mara"
+      thumb_height="230" caption="Hyenas at Maasai Mara"
       full_width="600" full_height="450"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/48740935151_cedbc943a3_o.jpg"
-      thumb_width="200" caption="Leopard laying around at Maasai Mara"
+      thumb_height="230" caption="Leopard laying around at Maasai Mara"
       full_width="600" full_height="450"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/48740606698_6ae7e8c66d_o.jpg"
-      thumb_width="210" caption="Lions at Maasai Mara"
+      thumb_height="230" caption="Lions at Maasai Mara"
       full_width="600" full_height="424"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/48740935211_3504edbc65_o.jpg"
-      thumb_width="200" caption="Yawning lion at Maasai Mara"
+      thumb_height="230" caption="Yawning lion at Maasai Mara"
       full_width="600" full_height="450"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/48740935321_f29e95c343_o.jpg"
-      thumb_width="225" caption="Warthogs at Maasai Mara"
+      thumb_height="230" caption="Warthogs at Maasai Mara"
       full_width="600" full_height="400"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/48741119787_f547fdb8b4_o.jpg"
-      thumb_width="225" caption="Wildebeests at Maasai Mara"
+      thumb_height="230" caption="Wildebeests at Maasai Mara"
       full_width="600" full_height="400"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/48740935386_f3d51837f8_o.jpg"
-      thumb_width="200" caption="Walking wildebeests at Maasai Mara"
+      thumb_height="230" caption="Walking wildebeests at Maasai Mara"
       full_width="600" full_height="450"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/48741119842_aa42e45571_o.jpg"
-      thumb_width="200" caption="Zebras at Maasai Mara"
+      thumb_height="230" caption="Zebras at Maasai Mara"
       full_width="600" full_height="446"
   %}
 </div>

--- a/_includes/elements/photo.html
+++ b/_includes/elements/photo.html
@@ -16,6 +16,18 @@
   {% endif %}
 {% endif %}
 
+{% if include.thumb_width %}
+  {% assign thumb_width = 'width="' | append: include.thumb_width | append: '"' %}
+{% else %}
+  {% assign thumb_width = "" %}
+{% endif %}
+
+{% if include.thumb_height %}
+  {% assign thumb_height = 'height="' | append: include.thumb_height | append: '"' %}
+{% else %}
+  {% assign thumb_height = "" %}
+{% endif %}
+
 {% if include.type == "lightbox2" %}
 
 {% if caption == "" %}
@@ -31,9 +43,9 @@
 {% endif %}
 
 {% if alt == "" %}
-<img class="image" src="{{ include.url }}" width="{{ include.thumb_width }}">
+<img class="image" src="{{ include.url }}" {{ thumb_width }} {{ thumb_height }} >
 {% else %}
-<img class="image" src="{{ include.url }}" width="{{ include.thumb_width }}" alt="{{ alt }}">
+<img class="image" src="{{ include.url }}" {{ thumb_width }} {{ thumb_height }} alt="{{ alt }}">
 {% endif %}
 
 {% unless include.type == "lightbox2" %}

--- a/assets/css/_links.scss
+++ b/assets/css/_links.scss
@@ -7,7 +7,7 @@ a:hover {
   color: #001aaf;
 }
 
-a:hover:not(.photoswipe, .lightbox2) {
+a:hover:not(.photoswipe, .lightbox2, .nav-link, .navbar-brand) {
   text-decoration: underline;
 }
 

--- a/assets/css/_site.scss
+++ b/assets/css/_site.scss
@@ -87,7 +87,6 @@ hr {
 
 .image {
   max-width: 100%;
-  height: auto;
   padding-bottom: .625rem;
 }
 

--- a/assets/js/activate_photoswipe.js
+++ b/assets/js/activate_photoswipe.js
@@ -20,19 +20,24 @@ lightbox.on('uiRegister', function () {
       lightbox.pswp.on('change', () => {
         const currentSlideElement = lightbox.pswp.currSlide.data.element
         const hiddenCaption = currentSlideElement.querySelector('.caption')
+        const customCaptionElements = document.getElementsByClassName('pswp__custom-caption')
+        let captionHTML = ''
 
         if (hiddenCaption === '' || hiddenCaption === null) {
-          const customCaptionElements = document.getElementsByClassName('pswp__custom-caption')
           for (let counter = 0; counter < customCaptionElements.length; counter++) {
-            customCaptionElements[counter].remove()
+            customCaptionElements[counter].classList.add('invisible')
           }
         } else {
-          let captionHTML = ''
+          for (let counter = 0; counter < customCaptionElements.length; counter++) {
+            customCaptionElements[counter].classList.remove('invisible')
+          }
+
           if (currentSlideElement) {
             captionHTML = hiddenCaption.innerHTML
           }
-          el.innerHTML = captionHTML || ''
         }
+
+        el.innerHTML = captionHTML
       })
     }
   })


### PR DESCRIPTION
## Changes

* Fix bug where hovering over navigation bar items underlines
* Fix bug where removing PhotoSwipe captions from items within a gallery causes other captions to be removed (and consequently, adding a caption to a gallery causes captions to be added to non-captioned photos)
* Allow thumb widths AND/OR thumb heights to be passed into PhotoSwipe and Lightbox2

## Related Pull Requests and Issues

> If applicable, a list of related pull requests and issues:
>
> * Issue URL link
> * Pull Request URL link

## Additional Context

> Add any other context about the problem here.

## PR Scheduler

> If you'd like to use the PR Scheduler, then add a comment to this pull request where the date/time is written in UTC and the pull request will merged and deployed at the date/time provided. The comment should look like this:
>
> ```
> # example (May 18, 2020 at 17:58 UTC):
> @prscheduler 2020-05-18 17:58
>
> @prscheduler YYYY-MM-DD HH:MM
> ```
