### PR TITLE
Move LEGO photos to use PhotoSwipe

### DIFF
--- a/_lego/box.md
+++ b/_lego/box.md
@@ -11,25 +11,30 @@ Here's a link to the instructions and piece list of the box: <a href="/assets/re
 
 NOTE: the piece list numbers can sometimes be out of sync with what's in the LEGO Bricks and Pieces database. Sometimes I need to do a more thorough Google search in order to find the correct piece number.
 
-<div class="text-center">
+<div class="text-center photoswipe-gallery">
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/49947517557_17d59cec8a_k.jpg"
-      thumb_width="200" caption="Box with squares on lid closed" lightbox_gallery="Box" type="lightbox2"
+      thumb_width="200" caption="Box with squares on lid closed"
+      full_width="2048" full_height="2048"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/49947231231_f1210a975c_k.jpg"
-      thumb_width="200" caption="Box with squares on lid open" lightbox_gallery="Box" type="lightbox2"
+      thumb_width="200" caption="Box with squares on lid open"
+      full_width="2048" full_height="2048"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/49947517287_14879a7720_k.jpg"
-      thumb_width="200" caption="Grey and black box closed" lightbox_gallery="Box" type="lightbox2"
+      thumb_width="200" caption="Grey and black box closed"
+      full_width="2048" full_height="2048"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/49946728308_34ba273aa0_k.jpg"
-      thumb_width="200" caption="Grey and black box closed from back" lightbox_gallery="Box" type="lightbox2"
+      thumb_width="200" caption="Grey and black box closed from back"
+      full_width="2048" full_height="2048"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/49947516887_e9bea792d3_k.jpg"
-      thumb_width="200" caption="Grey and black box opened" lightbox_gallery="Box" type="lightbox2"
+      thumb_width="200" caption="Grey and black box opened"
+      full_width="2048" full_height="2048"
   %}
 </div>

--- a/_lego/car.md
+++ b/_lego/car.md
@@ -13,21 +13,25 @@ NOTE: the piece list numbers can sometimes be out of sync with what's in the LEG
 
 Featured in the photographs are two minifigures I've designed (who I've named Taryn and Emmy for fun).
 
-<div class="text-center">
+<div class="text-center photoswipe-gallery">
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/49985840352_9032841264_b.jpg"
-      thumb_width="200" caption="Car front" lightbox_gallery="Car" type="lightbox2"
+      thumb_width="200" caption="Car front"
+      full_width="1024" full_height="768"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/49985585081_8a33a16dee_b.jpg"
-      thumb_width="200" caption="Car back" lightbox_gallery="Car" type="lightbox2"
+      thumb_width="200" caption="Car back"
+      full_width="1024" full_height="768"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/49985840327_da44a85b5d_b.jpg"
-      thumb_width="200" caption="Car with driver door open" lightbox_gallery="Car" type="lightbox2"
+      thumb_width="200" caption="Car with driver door open"
+      full_width="1024" full_height="768"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/49985065258_fdd7b8c519_b.jpg"
-      thumb_width="200" caption="Car top view" lightbox_gallery="Car" type="lightbox2"
+      thumb_width="200" caption="Car top view"
+      full_width="1024" full_height="768"
   %}
 </div>

--- a/_lego/cat.md
+++ b/_lego/cat.md
@@ -9,25 +9,30 @@ The crab was by far the cutest. Its claws were a stretch, but I do have to give 
 
 However, putting all three mini-sets together made for a fun little afternoon of LEGO. But if you're deciding to purchase this set (if it's even available for purchase), don't spend money hoping for an adorable little kitty, because what you'll actually get is the cat of your nightmares.
 
-<div class="text-center">
+<div class="text-center photoswipe-gallery">
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50528707218_cd8adc4a06_k.jpg"
-      thumb_width="150" caption="Crab front" lightbox_gallery="3-in-1 Cat" type="lightbox2"
+      thumb_height="150" caption="Crab front"
+      full_width="2048" full_height="1536"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50528707068_c97013d9b9_k.jpg"
-      thumb_width="150" caption="Crab side" lightbox_gallery="3-in-1 Cat" type="lightbox2"
+      thumb_height="150" caption="Crab side"
+      full_width="2048" full_height="1536"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50529431276_151eabda23_k.jpg"
-      thumb_width="150" caption="Ostrich" lightbox_gallery="3-in-1 Cat" type="lightbox2"
+      thumb_height="150" caption="Ostrich"
+      full_width="1536" full_height="2048"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50529431136_a8fc2fb67c_k.jpg"
-      thumb_width="150" caption="Ostrich closeup" lightbox_gallery="3-in-1 Cat" type="lightbox2"
+      thumb_height="150" caption="Ostrich closeup"
+      full_width="2048" full_height="1536"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50529431816_6bfcb77f81_k.jpg"
-      thumb_width="150" caption="Cat" lightbox_gallery="3-in-1 Cat" type="lightbox2"
+      thumb_height="150" caption="Cat"
+      full_width="2048" full_height="1536"
   %}
 </div>

--- a/_lego/charles-dickens-tribute.md
+++ b/_lego/charles-dickens-tribute.md
@@ -11,25 +11,30 @@ I think perhaps the greatest part of this set, though, is the fact that it has a
 
 Overall, the design of this little set was really great, and it was enjoyable to put together.
 
-<div class="text-center">
+<div class="text-center photoswipe-gallery">
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50700805371_5f07c1dfeb_k.jpg"
-      thumb_width="150" caption="Front of set" lightbox_gallery="Charles Dickens Tribute" type="lightbox2"
+      thumb_height="150" caption="Front of set"
+      full_width="2048" full_height="1536"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50700805361_0be9b0292a_k.jpg"
-      thumb_width="150" caption="Inside the house" lightbox_gallery="Charles Dickens Tribute" type="lightbox2"
+      thumb_height="150" caption="Inside the house"
+      full_width="2048" full_height="1536"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50700058708_585fd9f802_k.jpg"
-      thumb_width="100" caption="Birds-eye view featuring the drawer" lightbox_gallery="Charles Dickens Tribute" type="lightbox2"
+      thumb_height="150" caption="Birds-eye view featuring the drawer"
+      full_width="1536" full_height="2048"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50700887632_4df928110d_b.jpg"
-      thumb_width="150" caption="Outside" lightbox_gallery="Charles Dickens Tribute" type="lightbox2"
+      thumb_height="150" caption="Outside"
+      full_width="1024" full_height="768"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50700887962_14fa65a4d2_b.jpg"
-      thumb_width="150" caption="The back of the house" lightbox_gallery="Charles Dickens Tribute" type="lightbox2"
+      thumb_height="150" caption="The back of the house"
+      full_width="1024" full_height="768"
   %}
 </div>

--- a/_lego/diving-yacht.md
+++ b/_lego/diving-yacht.md
@@ -7,21 +7,25 @@ This diving yacht didn't have long instructions, and was enjoyable to put togeth
 
 Here's a link to the set: [Diving Yacht (60221)](https://www.lego.com/en-us/product/diving-yacht-60221)
 
-<div class="text-center">
+<div class="text-center photoswipe-gallery">
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/49977811291_ddb1464984_k.jpg"
-      thumb_width="200" caption="Yacht with cover" lightbox_gallery="Diving Yacht" type="lightbox2"
+      thumb_height="200" caption="Yacht with cover"
+      full_width="2048" full_height="1536"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/49978073062_941dcf47c0_k.jpg"
-      thumb_width="200" caption="Scuba diver underwater" lightbox_gallery="Diving Yacht" type="lightbox2"
+      thumb_height="200" caption="Scuba diver underwater"
+      full_width="2048" full_height="1536"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/49977291103_ef9e709552_k.jpg"
-      thumb_width="200" caption="Yacht with top off" lightbox_gallery="Diving Yacht" type="lightbox2"
+      thumb_height="200" caption="Yacht with top off"
+      full_width="1536" full_height="2048"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/49978072787_1a3a6f42eb_k.jpg"
-      thumb_width="200" caption="Two scuba divers underwater" lightbox_gallery="Diving Yacht" type="lightbox2"
+      thumb_height="200" caption="Two scuba divers underwater"
+      full_width="2048" full_height="1536"
   %}
 </div>

--- a/_lego/dorm-room-and-lounge.md
+++ b/_lego/dorm-room-and-lounge.md
@@ -15,25 +15,30 @@ Here's a link to the instructions and piece list of the dorm room: <a href="/ass
 
 NOTES: the piece list numbers can sometimes be out of sync with what's in the LEGO Bricks and Pieces database. Sometimes I need to do a more thorough Google search in order to find the correct piece number. Secondly, the windows that I decided to make the dorm room with aren't widely available on LEGO's website, so you may have to do some hunting to find those pieces.
 
-<div class="text-center">
+<div class="text-center photoswipe-gallery">
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50260267152_f4053082fd_k.jpg"
-      thumb_width="200" caption="Dorm Room top facing windows" lightbox_gallery="Dorm Room and Lounge" type="lightbox2"
+      thumb_width="200" caption="Dorm Room top facing windows"
+      full_width="2048" full_height="1536"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50260269917_27e84fe1eb_k.jpg"
-      thumb_width="200" caption="Dorm Room top facing napping minifigure" lightbox_gallery="Dorm Room and Lounge" type="lightbox2"
+      thumb_width="200" caption="Dorm Room top facing napping minifigure"
+      full_width="2048" full_height="1536"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50260269702_22fca19c1e_k.jpg"
-      thumb_width="200" caption="Dorm Room through window" lightbox_gallery="Dorm Room and Lounge" type="lightbox2"
+      thumb_width="200" caption="Dorm Room through window"
+      full_width="2048" full_height="1536"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50259424483_b8f67eca4c_k.jpg"
-      thumb_width="200" caption="Dorm Room top facing door" lightbox_gallery="Dorm Room and Lounge" type="lightbox2"
+      thumb_width="200" caption="Dorm Room top facing door"
+      full_width="2048" full_height="1536"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50260081341_d7a5d536ac_k.jpg"
-      thumb_width="200" caption="Dorm Room top with view of door" lightbox_gallery="Dorm Room and Lounge" type="lightbox2"
+      thumb_width="200" caption="Dorm Room top with view of door"
+      full_width="2048" full_height="1536"
   %}
 </div>

--- a/_lego/dorm-room-singles-with-bathroom.md
+++ b/_lego/dorm-room-singles-with-bathroom.md
@@ -15,21 +15,25 @@ Here's a link to the instructions and piece list of the dorm room: <a href="/ass
 
 NOTE: the piece list numbers can sometimes be out of sync with what's in the LEGO Bricks and Pieces database. Sometimes I need to do a more thorough Google search in order to find the correct piece number.
 
-<div class="text-center">
+<div class="text-center photoswipe-gallery">
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/51047685962_0fa6b4e205_z.jpg"
-      thumb_width="200" caption="Dorm Room vision of main room and shower" lightbox_gallery="Singles Dorm Room with Bathroom" type="lightbox2"
+      thumb_height="200" caption="Dorm Room vision of main room and shower"
+      full_width="640" full_height="592"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/51047685972_d1b2ed71d8_z.jpg"
-      thumb_width="200" caption="Dorm room birds-eye view" lightbox_gallery="Singles Dorm Room with Bathroom" type="lightbox2"
+      thumb_height="200" caption="Dorm room birds-eye view"
+      full_width="639" full_height="419"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50997044074_b5f7b32a49_z.jpg"
-      thumb_width="200" caption="Dorm room facing the TV and door" lightbox_gallery="Singles Dorm Room with Bathroom" type="lightbox2"
+      thumb_height="200" caption="Dorm room facing the TV and door"
+      full_width="640" full_height="461"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50997045260_772030fc4e_z.jpg"
-      thumb_width="200" caption="Dorm room with view of bathroom" lightbox_gallery="Singles Dorm Room with Bathroom" type="lightbox2"
+      thumb_height="200" caption="Dorm room with view of bathroom"
+      full_width="640" full_height="476"
   %}
 </div>

--- a/_lego/dorm-room-with-bathroom.md
+++ b/_lego/dorm-room-with-bathroom.md
@@ -15,21 +15,25 @@ Here's a link to the instructions and piece list of the dorm room: <a href="/ass
 
 NOTES: the piece list numbers can sometimes be out of sync with what's in the LEGO Bricks and Pieces database. Sometimes I need to do a more thorough Google search in order to find the correct piece number. Also, the mirror pieces in my below pictures are the wrong shade of blue... use your imagination.
 
-<div class="text-center">
+<div class="text-center photoswipe-gallery">
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50260080916_7e354f1ec9_k.jpg"
-      thumb_width="200" caption="Dorm Room top facing minifigures" lightbox_gallery="Dorm Room with Bathroom" type="lightbox2"
+      thumb_height="200" caption="Dorm Room top facing minifigures"
+      full_width="2048" full_height="1536"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50260266837_a97e901a44_k.jpg"
-      thumb_width="150" caption="Dorm Room top facing bathroom mirror" lightbox_gallery="Dorm Room with Bathroom" type="lightbox2"
+      thumb_height="200" caption="Dorm Room top facing bathroom mirror"
+      full_width="1536" full_height="2048"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50260080716_1672827dbe_k.jpg"
-      thumb_width="200" caption="Dorm Room top facing door" lightbox_gallery="Dorm Room with Bathroom" type="lightbox2"
+      thumb_height="200" caption="Dorm Room top facing door"
+      full_width="2048" full_height="1536"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50259423438_6359c73540_k.jpg"
-      thumb_width="200" caption="Dorm Room top facing door" lightbox_gallery="Dorm Room with Bathroom" type="lightbox2"
+      thumb_height="200" caption="Dorm Room top facing door"
+      full_width="2048" full_height="1536"
   %}
 </div>

--- a/_lego/dots-picture-frame.md
+++ b/_lego/dots-picture-frame.md
@@ -9,17 +9,20 @@ Here's a link to the set: [DOTS Picture Frame (41914)](https://www.lego.com/en-u
 
 Also featured in the last photograph is my personal minifigure that my coworker made at the LEGO store for me. Holding a wand, because I'm a _Harry Potter_ lover, and on a platform decorated with leftover DOTS pieces.
 
-<div class="text-center">
+<div class="text-center photoswipe-gallery">
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/49978623252_0e93eaca6d_k.jpg"
-      thumb_width="200" caption="DOTS frame design 1 forward" lightbox_gallery="DOTS frame" type="lightbox2"
+      thumb_height="200" caption="DOTS frame design 1 forward"
+      full_width="2048" full_height="2048"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/49978622887_5d44c13836_k.jpg"
-      thumb_width="200" caption="DOTS frame design 1 tilted" lightbox_gallery="DOTS frame" type="lightbox2"
+      thumb_height="200" caption="DOTS frame design 1 tilted"
+      full_width="1536" full_height="2048"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/49978362791_4b9eee62c1_k.jpg"
-      thumb_width="200" caption="DOTS frame and minifigure" lightbox_gallery="DOTS frame" type="lightbox2"
+      thumb_height="200" caption="DOTS frame and minifigure"
+      full_width="2048" full_height="1536"
   %}
 </div>

--- a/_lego/fairground.md
+++ b/_lego/fairground.md
@@ -13,21 +13,25 @@ In my pictures, I added a green floor to keep all of the pieces together and sta
 
 Here's a link to the set: [People Pack – Fun Fair (60234)](https://www.lego.com/en-us/product/people-pack-fun-fair-60234)
 
-<div class="text-center">
+<div class="text-center photoswipe-gallery">
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50050571391_c25a153b4f_k.jpg"
-      thumb_width="200" caption="Fairground front" lightbox_gallery="Fairground" type="lightbox2"
+      thumb_width="200" caption="Fairground front"
+      full_width="2048" full_height="1536"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50050003703_039321bf98_k.jpg"
-      thumb_width="200" caption="Fairground back" lightbox_gallery="Fairground" type="lightbox2"
+      thumb_width="200" caption="Fairground back"
+      full_width="2048" full_height="1536"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50050573421_9b12a93862_k.jpg"
-      thumb_width="200" caption="Fairground side" lightbox_gallery="Fairground" type="lightbox2"
+      thumb_width="200" caption="Fairground side"
+      full_width="2048" full_height="1536"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50050009548_b31c09f6d8_k.jpg"
-      thumb_width="200" caption="Fairground top" lightbox_gallery="Fairground" type="lightbox2"
+      thumb_width="200" caption="Fairground top"
+      full_width="2048" full_height="1536"
   %}
 </div>

--- a/_lego/flower-display.md
+++ b/_lego/flower-display.md
@@ -9,17 +9,20 @@ My partner had the inkling that I would enjoy LEGO since he saw me enjoy putting
 
 Here's a link to the set: [Flower Display (40187)](https://www.lego.com/en-us/product/lego-flower-display-40187)
 
-<div class="text-center">
+<div class="text-center photoswipe-gallery">
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50072954358_4a7a32c1bd_k.jpg"
-      thumb_width="200" caption="Flower Display side by side" lightbox_gallery="Flower Display" type="lightbox2"
+      thumb_width="200" caption="Flower Display side by side"
+      full_width="2048" full_height="1536"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50073521936_c0875a095f_k.jpg"
-      thumb_width="200" caption="Flower Display top" lightbox_gallery="Flower Display" type="lightbox2"
+      thumb_width="200" caption="Flower Display top"
+      full_width="2048" full_height="1536"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50073521861_e393dd2977_k.jpg"
-      thumb_width="200" caption="Flower Display showcasing depth" lightbox_gallery="Flower Display" type="lightbox2"
+      thumb_width="200" caption="Flower Display showcasing depth"
+      full_width="2048" full_height="1536"
   %}
 </div>

--- a/_lego/helicopter-adventure.md
+++ b/_lego/helicopter-adventure.md
@@ -7,29 +7,35 @@ This fun 3-in-1 is a joy to use. All of the sets are simple to follow, and each 
 
 Here's a link to the set: [Helicopter Adventure (31092)](https://www.lego.com/en-us/product/helicopter-adventure-31092)
 
-<div class="text-center">
+<div class="text-center photoswipe-gallery">
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/49977843728_9fc00bb86e_k.jpg"
-      thumb_width="150" caption="Helicopter front" lightbox_gallery="LEGO 3-in-1 Creator085" type="lightbox2"
+      thumb_height="150" caption="Helicopter front"
+      full_width="2048" full_height="1536"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/49978363246_77d3d3a753_k.jpg"
-      thumb_width="150" caption="Helicopter back" lightbox_gallery="LEGO 3-in-1 Creator085" type="lightbox2"
+      thumb_height="150" caption="Helicopter back"
+      full_width="2048" full_height="1536"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/49978363141_99b96ba922_k.jpg"
-      thumb_width="150" caption="Steamboat front" lightbox_gallery="LEGO 3-in-1 Creator085" type="lightbox2"
+      thumb_height="150" caption="Steamboat front"
+      full_width="2048" full_height="1536"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/49978362646_a50bd0f186_k.jpg"
-      thumb_width="150" caption="Steamboat back" lightbox_gallery="LEGO 3-in-1 Creator085" type="lightbox2"
+      thumb_height="150" caption="Steamboat back"
+      full_width="1536" full_height="2048"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/49978623487_2fa36eec74_k.jpg"
-      thumb_width="150" caption="Plane front" lightbox_gallery="LEGO 3-in-1 Creator085" type="lightbox2"
+      thumb_height="150" caption="Plane front"
+      full_width="2048" full_height="1536"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/49978362526_df871ac79c_k.jpg"
-      thumb_width="150" caption="Plane back" lightbox_gallery="LEGO 3-in-1 Creator085" type="lightbox2"
+      thumb_height="150" caption="Plane back"
+      full_width="1536" full_height="2048"
   %}
 </div>

--- a/_lego/monkie-kid.md
+++ b/_lego/monkie-kid.md
@@ -7,13 +7,15 @@ In normal circumstances, I wouldn't purchase any LEGO sets from _Monkie Kid_. I'
 
 Putting together the little motorcycle was fun, and the minifigure's facial expressions are definitely worth it. All-in-all, it was a fun little 10 minutes to spend doing LEGO. I wouldn't spend any actual money on this set though.
 
-<div class="text-center">
+<div class="text-center photoswipe-gallery">
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50528707783_398f54beda_k.jpg"
-      thumb_width="150" caption="Monkie Kid" lightbox_gallery="Monkie Kid" type="lightbox2"
+      thumb_width="250" caption="Monkie Kid"
+      full_width="2048" full_height="1536"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50529431976_26d9c0c547_k.jpg"
-      thumb_width="150" caption="Monkie Kid" lightbox_gallery="Monkie Kid" type="lightbox2"
+      thumb_width="250" caption="Monkie Kid"
+      full_width="2048" full_height="1536"
   %}
 </div>

--- a/_lego/raft.md
+++ b/_lego/raft.md
@@ -7,21 +7,25 @@ This cute little raft was made from pieces that I found in my LEGO piece stash. 
 
 The minifigures were designed by myself, and I specifically ordered top, bottom, face, and hair pieces of each minifigure (named Ben and Olivia). The chain is the finishing touch, and allows the raft to be hooked up to a dock.
 
-<div class="text-center">
+<div class="text-center photoswipe-gallery">
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50072953968_e15523675c_k.jpg"
-      thumb_width="200" caption="Raft Front" lightbox_gallery="Raft" type="lightbox2"
+      thumb_width="200" caption="Raft Front"
+      full_width="2048" full_height="1536"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50072953903_4a5356bea5_k.jpg"
-      thumb_width="200" caption="Raft Back" lightbox_gallery="Raft" type="lightbox2"
+      thumb_width="200" caption="Raft Back"
+      full_width="2048" full_height="1536"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50073521516_072e24ab86_k.jpg"
-      thumb_width="200" caption="Raft hooked on 'dock'" lightbox_gallery="Raft" type="lightbox2"
+      thumb_width="200" caption="Raft hooked on 'dock'"
+      full_width="2048" full_height="1536"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50072953783_a32953e624_k.jpg"
-      thumb_width="200" caption="Raft top" lightbox_gallery="Raft" type="lightbox2"
+      thumb_width="200" caption="Raft top"
+      full_width="2048" full_height="1536"
   %}
 </div>

--- a/_lego/toy-store.md
+++ b/_lego/toy-store.md
@@ -7,53 +7,65 @@ This 3-in-1 Toy Store was such a joy to put together. I put together all 3 sets,
 
 Note that for the pictures of the Toy Store, I've substituted the female minifigure's yellow top for the red top, and then put the child minifigure in a green top that didn't come in the original set.
 
-<div class="text-center">
+<div class="text-center photoswipe-gallery">
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50762710118_a3d446843e_b.jpg"
-      thumb_width="200" caption="Inside the Flower Shop" lightbox_gallery="Townhouse Toy Store" type="lightbox2"
+      thumb_height="150" caption="Inside the Flower Shop"
+      full_width="1024" full_height="768"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50763556647_4501aef110_b.jpg"
-      thumb_width="200" caption="Birds-eye view of the Flower Shop" lightbox_gallery="Townhouse Toy Store" type="lightbox2"
+      thumb_height="150" caption="Birds-eye view of the Flower Shop"
+      full_width="1024" full_height="768"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50762710143_aa0cee55fe_b.jpg"
-      thumb_width="200" caption="Outside the Flower Shop" lightbox_gallery="Townhouse Toy Store" type="lightbox2"
+      thumb_height="150" caption="Outside the Flower Shop"
+      full_width="1024" full_height="768"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50762710538_d71f7454c5_b.jpg"
-      thumb_width="200" caption="Inside the Cake Shop" lightbox_gallery="Townhouse Toy Store" type="lightbox2"
+      thumb_height="150" caption="Inside the Cake Shop"
+      full_width="1024" full_height="768"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50763557092_93aa5916cc_b.jpg"
-      thumb_width="200" caption="Inside the Cake Shop with a view of the office" lightbox_gallery="Townhouse Toy Store" type="lightbox2"
+      thumb_height="150" caption="Inside the Cake Shop with a view of the office"
+      full_width="1024" full_height="768"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50763441926_5afcab9d6c_b.jpg"
-      thumb_width="200" caption="Outside the Cake Shop looking at the padio" lightbox_gallery="Townhouse Toy Store" type="lightbox2"
+      thumb_height="150" caption="Outside the Cake Shop looking at the patio"
+      full_width="1024" full_height="768"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50762710593_669b9abd25_b.jpg"
-      thumb_width="150" caption="Outside the Cake Shop" lightbox_gallery="Townhouse Toy Store" type="lightbox2"
+      thumb_height="150" caption="Outside the Cake Shop"
+      full_width="768" full_height="1024"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50763556972_333d62e86b_b.jpg"
-      thumb_width="200" caption="Outside the Cake Shop from the side" lightbox_gallery="Townhouse Toy Store" type="lightbox2"
+      thumb_height="150" caption="Outside the Cake Shop from the side"
+      full_width="1024" full_height="768"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50763441226_944c1dd5e7_b.jpg"
-      thumb_width="200" caption="Outside the front of the Toy Store" lightbox_gallery="Townhouse Toy Store" type="lightbox2"
+      thumb_height="150" caption="Outside the front of the Toy Store"
+      full_width="1024" full_height="768"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50762709833_ec1de79915_b.jpg"
-      thumb_width="150" caption="Outside the side of the Toy Store" lightbox_gallery="Townhouse Toy Store" type="lightbox2"
+      thumb_height="150" caption="Outside the side of the Toy Store"
+      full_width="768" full_height="1024"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50763441196_a3085ce780_b.jpg"
-      thumb_width="150" caption="Inside the Toy Store" lightbox_gallery="Townhouse Toy Store" type="lightbox2"
+      thumb_height="150" caption="Inside the Toy Store"
+      full_width="768" full_height="1024"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50762790398_764395d9b9_b.jpg"
-      thumb_width="200" caption="The Toy Store with floors separated" lightbox_gallery="Townhouse Toy Store" type="lightbox2"
+      thumb_height="150" caption="The Toy Store with floors separated"
+      full_width="1024" full_height="768"
   %}
 </div>

--- a/_lego/unikitty-cart.md
+++ b/_lego/unikitty-cart.md
@@ -9,17 +9,20 @@ However, it was a fun little set to put together. The wagon actually rolls, and 
 
 Here's a link to the set: [Unikitty Roller Coaster Wagon (30406)](https://www.lego.com/en-us/product/unikitty-roller-coaster-wagon-30406)
 
-<div class="text-center">
+<div class="text-center photoswipe-gallery">
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50072954158_32c27268d2_k.jpg"
-      thumb_width="200" caption="Cart Front" lightbox_gallery="Unikitty Cart" type="lightbox2"
+      thumb_width="200" caption="Cart Front"
+      full_width="2048" full_height="1536"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50072954108_abe06bd835_k.jpg"
-      thumb_width="200" caption="Cart Back" lightbox_gallery="Unikitty Cart" type="lightbox2"
+      thumb_width="200" caption="Cart Back"
+      full_width="2048" full_height="1536"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50073521661_37680a69e1_k.jpg"
-      thumb_width="200" caption="Cart with piece ejected out" lightbox_gallery="Unikitty Cart" type="lightbox2"
+      thumb_width="200" caption="Cart with piece ejected out"
+      full_width="2048" full_height="1536"
   %}
 </div>


### PR DESCRIPTION
## Changes

Transfer more LEGO photos to use PhotoSwipe. The only two LEGO sets left to transfer over are the Disney Princess Storybooks and the Harry Potter pictures.

## Related Pull Requests and Issues

Transferring of more blog posts happened in: https://github.com/emmahsax/emmahsax.github.io/pull/396 and https://github.com/emmahsax/emmahsax.github.io/pull/395.

## Additional Context

> Add any other context about the problem here.

## PR Scheduler

> If you'd like to use the PR Scheduler, then add a comment to this pull request where the date/time is written in UTC and the pull request will merged and deployed at the date/time provided. The comment should look like this:
>
> ```
> # example (May 18, 2020 at 17:58 UTC):
> @prscheduler 2020-05-18 17:58
>
> @prscheduler YYYY-MM-DD HH:MM
> ```
