### PR TITLE
Transition the rest of Lightbox2 photos to PhotoSwipe

### DIFF
--- a/.github/contributing.md
+++ b/.github/contributing.md
@@ -357,8 +357,8 @@ Alternatively, to use PhotoSwipe to make the photo clickable, and then it'll zoo
   {% include elements/photo.html
       url="/assets/images/picture-01.jpg"
       thumb_width="200" thumb_height="230
-      caption="Caption will show when the photo is enlarged" alt="Alt shows if the photo cannot be shown"
       full_width="400" full_height="200"
+      caption="Caption will show when the photo is enlarged" alt="Alt shows if the photo cannot be shown"
   %}
 </div>
 ```
@@ -371,8 +371,8 @@ Using Lightbox2 in order to make photos clickable is also an option, but this is
 {% include elements/photo.html
     url="/assets/images/picture-01.jpg"
     thumb_width="200" thumb_height="230
-    caption="Caption will show when the photo is enlarged" alt="Alt shows if the photo cannot be shown"
     lightbox_gallery="Lightbox Gallery Name" type="lightbox2"
+    caption="Caption will show when the photo is enlarged" alt="Alt shows if the photo cannot be shown"
 %}
 ```
 

--- a/_lego/disney-princess-storybooks.md
+++ b/_lego/disney-princess-storybooks.md
@@ -18,81 +18,100 @@ Here are their links:
 * [Ariel's Storybook Adventures (43176)](https://www.lego.com/en-us/product/ariel-s-storybook-adventures-43176)
 * [Belle's Storybook Adventures (43177)](https://www.lego.com/en-us/product/belle-s-storybook-adventures-43177)
 
-<div class="text-center">
+<div class="text-center photoswipe-gallery">
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50073767857_581d46f6ba_b.jpg"
-      thumb_width="265" caption="Storybooks all facing front" lightbox_gallery="Disney Storybook Adventures" type="lightbox2"
+      thumb_width="265" caption="Storybooks all facing front"
+      full_width="1024" full_height="565"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50072953473_ced1aba3fe_b.jpg"
-      thumb_width="200" caption="Storybooks from top" lightbox_gallery="Disney Storybook Adventures" type="lightbox2"
+      thumb_width="200" caption="Storybooks from top"
+      full_width="1024" full_height="768"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50072953418_f5729685e4_b.jpg"
-      thumb_width="200" caption="Storybooks at diagonal" lightbox_gallery="Disney Storybook Adventures" type="lightbox2"
+      thumb_width="200" caption="Storybooks at diagonal"
+      full_width="1024" full_height="768"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50073767592_a7b5c7fa25_b.jpg"
-      thumb_width="200" caption="Storybooks from the back" lightbox_gallery="Disney Storybook Adventures" type="lightbox2"
+      thumb_width="200" caption="Storybooks from the back"
+      full_width="1024" full_height="768"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50073520906_15d6211ab4_b.jpg"
-      thumb_width="200" caption="Storybooks from the side" lightbox_gallery="Disney Storybook Adventures" type="lightbox2"
+      thumb_width="200" caption="Storybooks from the side"
+      full_width="1024" full_height="768"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50073768857_d40e8f5e21_b.jpg"
-      thumb_width="200" caption="Beauty and the Beast courtyard" lightbox_gallery="Disney Storybook Adventures" type="lightbox2"
+      thumb_width="200" caption="Beauty and the Beast courtyard"
+      full_width="1024" full_height="768"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50073522166_892972f23d_b.jpg"
-      thumb_width="200" caption="Beauty and the Beast ballroom" lightbox_gallery="Disney Storybook Adventures" type="lightbox2"
+      thumb_width="200" caption="Beauty and the Beast ballroom"
+      full_width="1024" full_height="768"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50073766857_7571423bec_b.jpg"
-      thumb_width="200" caption="Beauty and the Beast top" lightbox_gallery="Disney Storybook Adventures" type="lightbox2"
+      thumb_width="200" caption="Beauty and the Beast top"
+      full_width="1024" full_height="768"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50073768732_dc58b62142_b.jpg"
-      thumb_width="200" caption="The Little Mermaid beach" lightbox_gallery="Disney Storybook Adventures" type="lightbox2"
+      thumb_width="200" caption="The Little Mermaid beach"
+      full_width="1024" full_height="768"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50073522061_963a5ef075_b.jpg"
-      thumb_width="200" caption="The Little Mermaid under the sea" lightbox_gallery="Disney Storybook Adventures" type="lightbox2"
+      thumb_width="200" caption="The Little Mermaid under the sea"
+      full_width="1024" full_height="768"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50073766797_6d43b19eef_b.jpg"
-      thumb_width="200" caption="The Little Mermaid top" lightbox_gallery="Disney Storybook Adventures" type="lightbox2"
+      thumb_width="200" caption="The Little Mermaid top"
+      full_width="1024" full_height="768"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50073520846_c68a00f9b4_b.jpg"
-      thumb_width="200" caption="Frozen indoors close-up" lightbox_gallery="Disney Storybook Adventures" type="lightbox2"
+      thumb_width="200" caption="Frozen indoors close-up"
+      full_width="" full_height=""
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50072953068_3b38fb07a0_b.jpg"
-      thumb_width="200" caption="Frozen indoors" lightbox_gallery="Disney Storybook Adventures" type="lightbox2"
+      thumb_width="200" caption="Frozen indoors"
+      full_width="1024" full_height="768"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50073520691_e54949b788_b.jpg"
-      thumb_width="200" caption="Frozen outdoors" lightbox_gallery="Disney Storybook Adventures" type="lightbox2"
+      thumb_width="200" caption="Frozen outdoors"
+      full_width="1024" full_height="768"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50073520256_5f2be8156b_b.jpg"
-      thumb_width="200" caption="Frozen top" lightbox_gallery="Disney Storybook Adventures" type="lightbox2"
+      thumb_width="200" caption="Frozen top"
+      full_width="1024" full_height="768"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50073520646_a176a34a3a_b.jpg"
-      thumb_width="200" caption="Mulan at home" lightbox_gallery="Disney Storybook Adventures" type="lightbox2"
+      thumb_width="200" caption="Mulan at home"
+      full_width="1024" full_height="768"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50073520601_ae8e013d06_b.jpg"
-      thumb_width="200" caption="Mulan at the army camp" lightbox_gallery="Disney Storybook Adventures" type="lightbox2"
+      thumb_width="200" caption="Mulan at the army camp"
+      full_width="1024" full_height="768"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50073766997_8d946b0458_b.jpg"
-      thumb_width="200" caption="Mulan at the army camp straight ahead" lightbox_gallery="Disney Storybook Adventures" type="lightbox2"
+      thumb_width="200" caption="Mulan at the army camp straight ahead"
+      full_width="1024" full_height="768"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50073520461_d14e47fdb4_b.jpg"
-      thumb_width="200" caption="Mulan top" lightbox_gallery="Disney Storybook Adventures" type="lightbox2"
+      thumb_width="200" caption="Mulan top"
+      full_width="1024" full_height="768"
   %}
 </div>

--- a/_lego/harry-potter.md
+++ b/_lego/harry-potter.md
@@ -30,113 +30,140 @@ Here's a list of all of the _Harry Potter_ LEGO sets shown:
 
 I have dreams of also getting the [Diagon Alley (75978)](https://www.lego.com/en-us/product/diagon-alley-75978) set as well and adding that to my collection, but I don't have the physical space right now to display that set.
 
-<div class="text-center">
+<div class="text-center photoswipe-gallery">
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50260270132_90e5ed62e9_k.jpg"
-      thumb_width="150" caption="Inside the Knight Bus" lightbox_gallery="Harry Potter" type="lightbox2"
+      thumb_height="150" caption="Inside the Knight Bus"
+      full_width="2048" full_height="1536"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50260082281_0fdb0d5d79_k.jpg"
-      thumb_width="150" caption="Knight Bus outside" lightbox_gallery="Harry Potter" type="lightbox2"
+      thumb_height="150" caption="Knight Bus outside"
+      full_width="2048" full_height="1536"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50260079471_33079b5531_k.jpg"
-      thumb_width="150" caption="Platform 9 3/4 and the Hogwarts Express" lightbox_gallery="Harry Potter" type="lightbox2"
+      thumb_height="150" caption="Platform 9 3/4 and the Hogwarts Express"
+      full_width="2048" full_height="1536"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50260082536_6fc732146c_k.jpg"
-      thumb_width="150" caption="Saving Buckbeak" lightbox_gallery="Harry Potter" type="lightbox2"
+      thumb_height="150" caption="Saving Buckbeak"
+      full_width="2048" full_height="1536"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50260082686_17a5d1b217_k.jpg"
-      thumb_width="150" caption="Inside Hagrid's house" lightbox_gallery="Harry Potter" type="lightbox2"
+      thumb_height="150" caption="Inside Hagrid's house"
+      full_width="2048" full_height="1536"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50259425778_fce9316f95_k.jpg"
-      thumb_width="150" caption="Resurrecting Voldemort and the Womping Willow" lightbox_gallery="Harry Potter" type="lightbox2"
+      thumb_height="150" caption="Resurrecting Voldemort and the Womping Willow"
+      full_width="2048" full_height="1536"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50260083081_7352563c92_k.jpg"
-      thumb_width="150" caption="Saving Sirius and Aragog's lair" lightbox_gallery="Harry Potter" type="lightbox2"
+      thumb_height="150" caption="Saving Sirius and Aragog's lair"
+      full_width="2048" full_height="1536"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50260271152_a0d363ae68_k.jpg"
-      thumb_width="150" caption="The first Quidditch match" lightbox_gallery="Harry Potter" type="lightbox2"
+      thumb_height="150" caption="The first Quidditch match"
+      full_width="2048" full_height="1536"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50260271292_c6a992978e_k.jpg"
-      thumb_width="150" caption="The Yule Ball" lightbox_gallery="Harry Potter" type="lightbox2"
+      thumb_height="150" caption="The Yule Ball"
+      full_width="2048" full_height="1536"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50260083901_3314fb37fe_k.jpg"
-      thumb_width="150" caption="In the Great Hall" lightbox_gallery="Harry Potter" type="lightbox2"
+      thumb_height="150" caption="In the Great Hall"
+      full_width="2048" full_height="1536"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50260083631_d868d87b7a_k.jpg"
-      thumb_width="150" caption="Hogwarts interior" lightbox_gallery="Harry Potter" type="lightbox2"
+      thumb_height="150" caption="Hogwarts interior"
+      full_width="1536" full_height="2048"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50529240111_565bacd9d0_k.jpg"
-      thumb_width="150" caption="Full Astronomy Tower" lightbox_gallery="Harry Potter" type="lightbox2"
+      thumb_height="150" caption="Full Astronomy Tower"
+      full_width="1536" full_height="2048"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50528515018_ed2c41f2f7_k.jpg"
-      thumb_width="150" caption="The Astronomy Tower and Ravenclaw common room" lightbox_gallery="Harry Potter" type="lightbox2"
+      thumb_height="150" caption="The Astronomy Tower and Ravenclaw common room"
+      full_width="1536" full_height="2048"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50529240681_edd2c03ca4_k.jpg"
-      thumb_width="150" caption="Slughorn's dinner party" lightbox_gallery="Harry Potter" type="lightbox2"
+      thumb_height="150" caption="Slughorn's dinner party"
+      full_width="2048" full_height="1536"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50529397092_667eee3c6b_k.jpg"
-      thumb_width="150" caption="Inside the Room of Requirement" lightbox_gallery="Harry Potter" type="lightbox2"
+      thumb_height="150" caption="Inside the Room of Requirement"
+      full_width="2048" full_height="1536"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50529396827_9e340a530b_k.jpg"
-      thumb_width="150" caption="Outside the Room of Requirement" lightbox_gallery="Harry Potter" type="lightbox2"
+      thumb_height="150" caption="Outside the Room of Requirement"
+      full_width="2048" full_height="1536"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50529239156_814471dde5_k.jpg"
-      thumb_width="150" caption="Grawp" lightbox_gallery="Harry Potter" type="lightbox2"
+      thumb_height="150" caption="Grawp"
+      full_width="1536" full_height="2048"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50529396302_610970ed7a_k.jpg"
-      thumb_width="150" caption="Umbridge's encounter with Grawp" lightbox_gallery="Harry Potter" type="lightbox2"
+      thumb_height="150" caption="Umbridge's encounter with Grawp"
+      full_width="2048" full_height="1536"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50528513518_d4d4249667_k.jpg"
-      thumb_width="150" caption="The Burrow's living room" lightbox_gallery="Harry Potter" type="lightbox2"
+      thumb_height="150" caption="The Burrow's living room"
+      full_width="2048" full_height="1536"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50529395712_20af0da1cb_k.jpg"
-      thumb_width="150" caption="The Burrow's kitchen" lightbox_gallery="Harry Potter" type="lightbox2"
+      thumb_height="150" caption="The Burrow's kitchen"
+      full_width="2048" full_height="1536"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50529395427_66bd0ed8d2_k.jpg"
-      thumb_width="150" caption="The Burrow's bedrooms" lightbox_gallery="Harry Potter" type="lightbox2"
+      thumb_height="150" caption="The Burrow's bedrooms"
+      full_width="1536" full_height="2048"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50529237731_d510a02dbe_k.jpg"
-      thumb_width="150" caption="The Burrow from the outside" lightbox_gallery="Harry Potter" type="lightbox2"
+      thumb_height="150" caption="The Burrow from the outside"
+      full_width="1536" full_height="2048"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50529395067_6ce76369f3_k.jpg"
-      thumb_width="150" caption="Inside 4 Privet Drive" lightbox_gallery="Harry Potter" type="lightbox2"
+      thumb_height="150" caption="Inside 4 Privet Drive"
+      full_width="2048" full_height="1536"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50529237346_72ed426611_k.jpg"
-      thumb_width="150" caption="4 Privet Drive: Harry's escape" lightbox_gallery="Harry Potter" type="lightbox2"
+      thumb_height="150" caption="4 Privet Drive: Harry's escape"
+      full_width="2048" full_height="1536"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50529392727_4122044f0d_k.jpg"
-      thumb_width="150" caption="The Great Hall from the outside" lightbox_gallery="Harry Potter" type="lightbox2"
+      thumb_height="150" caption="The Great Hall from the outside"
+      full_width="2048" full_height="1536"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50528512098_ca1dd38a7d_k.jpg"
-      thumb_width="150" caption="Hogwarts from the outside" lightbox_gallery="Harry Potter" type="lightbox2"
+      thumb_height="150" caption="Hogwarts from the outside"
+      full_width="2048" full_height="1536"
   %}
   {% include elements/photo.html
       url="https://live.staticflickr.com/65535/50529236341_3c3d4a1be6_k.jpg"
-      thumb_width="150" caption="Hogwarts panorama" lightbox_gallery="Harry Potter" type="lightbox2"
+      thumb_height="150" caption="Hogwarts panorama"
+      full_width="2048" full_height="691"
   %}
 </div>


### PR DESCRIPTION
## Changes

Turning the remaining of the Lightbox2 photos (except the ones in the lightbox2 blog post) into PhotoSwipe photos. This is particularly focusing on the Harry Potter and Disney Princess Storybook LEGO photos.

## Related Pull Requests and Issues

* https://github.com/emmahsax/emmahsax.github.io/pull/404
* https://github.com/emmahsax/emmahsax.github.io/pull/396
* https://github.com/emmahsax/emmahsax.github.io/pull/395

## Additional Context

> Add any other context about the problem here.

## PR Scheduler

> If you'd like to use the PR Scheduler, then add a comment to this pull request where the date/time is written in UTC and the pull request will merged and deployed at the date/time provided. The comment should look like this:
>
> ```
> # example (May 18, 2020 at 17:58 UTC):
> @prscheduler 2020-05-18 17:58
>
> @prscheduler YYYY-MM-DD HH:MM
> ```
