### PR TITLE
Fix more bad underlining on hover

### DIFF
--- a/_includes/elements/active_page.html
+++ b/_includes/elements/active_page.html
@@ -1,3 +1,3 @@
 <li class="page-item active">
-  <a class="page-link">{{ page_number }}</a>
+  <a class="page-link button-text">{{ page_number }}</a>
 </li>

--- a/_includes/elements/all_posts_button.html
+++ b/_includes/elements/all_posts_button.html
@@ -1,3 +1,3 @@
 <div class="container padding-bottom-1">
-  <a href="/blog/" class="btn btn-lg btn-outline-secondary">All Posts</a>
+  <a href="/blog/" class="btn btn-lg btn-outline-secondary button-text">All Posts</a>
 </div>

--- a/_includes/elements/numbered_page.html
+++ b/_includes/elements/numbered_page.html
@@ -16,5 +16,5 @@
 {% endif %}
 
 <li class="page-item">
-  <a class="page-link" href="{{ blog_url }}">{{ page_number }}</a>
+  <a class="page-link button-text" href="{{ blog_url }}">{{ page_number }}</a>
 </li>

--- a/_layouts/index.html
+++ b/_layouts/index.html
@@ -44,8 +44,8 @@ layout: default
           <i data-feather="facebook"></i>
         </a>
 
-        <div class="text-center link-icon-button contact-button">
-          <a href="/contact-me/" class="btn btn-md btn-outline-secondary">
+        <div class="text-center contact-button">
+          <a href="/contact-me/" class="btn btn-md btn-outline-secondary button-text">
             Send me a message directly
           </a>
         </div>

--- a/assets/css/_links.scss
+++ b/assets/css/_links.scss
@@ -7,23 +7,13 @@ a:hover {
   color: #001aaf;
 }
 
-a:hover:not(.photoswipe, .lightbox2, .nav-link, .navbar-brand) {
+a:hover:not(
+  .photoswipe, .lightbox2,
+  .nav-link, .navbar-brand,
+  .link-icon, .link-icon-rss,
+  .button-text
+) {
   text-decoration: underline;
-}
-
-.link-icon-button > a {
-  svg {
-    height: 3rem;
-    width: 3rem;
-    transition: stroke .15s ease-in-out;
-  }
-
-  &:hover,
-  &:active {
-    svg {
-      stroke: white;
-    }
-  }
 }
 
 .link-icon-rss {


### PR DESCRIPTION
## Changes

A few more items are showing that little underlining when hovering:
* The picture-icons on the homepage
* The buttons (contact button, all posts button)
* The pagination bar on the bottom of the blog post lists

And then this also removes some outdated CSS code that's no longer used.

## Related Pull Requests and Issues

* https://github.com/emmahsax/emmahsax.github.io/pull/400

## Additional Context

> Add any other context about the problem here.

## PR Scheduler

> If you'd like to use the PR Scheduler, then add a comment to this pull request where the date/time is written in UTC and the pull request will merged and deployed at the date/time provided. The comment should look like this:
>
> ```
> # example (May 18, 2020 at 17:58 UTC):
> @prscheduler 2020-05-18 17:58
>
> @prscheduler YYYY-MM-DD HH:MM
> ```
