### PR TITLE
Lightbox2 to PhotoSwipe blog post

### DIFF
--- a/_blog_posts/301-redirects-with-static-sites.md
+++ b/_blog_posts/301-redirects-with-static-sites.md
@@ -56,7 +56,7 @@ So, the first thing I did was add CSS. I copy-pasted the `./assets/` directory f
 
 And then the last couple tricks was to add two ways to do the redirect. One was a delayed redirect. So a user would sit on the redirect page for five seconds to be able to comprehend what was happening and then they'd be automatically redirected. The second was for an easy way for the user to redirect themselves. This eventually turned into a button. The tricky part of both of these was forwarding the incoming path. It turns out, the easiest way to do this is to actually use Javascript instead of HTML, like the original blog post suggests. For example, this is how you could read the incoming path that is navigated to, and pass it on in a delayed redirect:
 
-```js
+```javascript
 pathname = window.location.pathname;
 setTimeout(function(){ window.location.href = "https://destination-domain.com" + pathname;}, 5000);
 ```

--- a/_blog_posts/turning-lightbox2-into-photoswipe.md
+++ b/_blog_posts/turning-lightbox2-into-photoswipe.md
@@ -3,16 +3,16 @@ layout: post
 title: Turning Lightbox2 into PhotoSwipe
 tags: [ tech, jekyll ]
 permalink: /blog/posts/turning-lightbox2-into-photoswipe/
-draft: true
+date: 2021-06-14 12:00:00 -0500
 ---
 
-Last August, I made a big push to add better photo functionality to my website. I added [Lightbox2](https://lokeshdhakar.com/projects/lightbox2/), by @lokesh, to my site. In a [previous blog post](/blog/posts/adding-lightbox-to-a-jekyll-website/), I referenced it as plain Lightbox. It turns out that Lightbox2 is built upon Lightbox JS, by the same author. But technically, I incorporated Lightbox2 to my site.
+In August of 2020, I made a big push to add better photo functionality to my website. I added [Lightbox2](https://lokeshdhakar.com/projects/lightbox2/), by @lokesh, to my site. In a [previous blog post](/blog/posts/adding-lightbox-to-a-jekyll-website/), I referenced it as plain Lightbox. It turns out that Lightbox2 is built upon Lightbox JS, by the same author. But technically, I incorporated Lightbox2.
 
-But recently, upon the advice of an old schoolmate, I came across [PhotoSwipe](https://photoswipe.com/). PhotoSwipe provides similar abilities to Lightbox2, but also provides zooming, faster loading, and swipe actions, as well as clicking and arrow key pressing. This is a definite benefit for viewing the site on mobile.
+But recently, upon the advice of an old schoolmate, I came across [PhotoSwipe](https://photoswipe.com/). PhotoSwipe provides similar abilities to Lightbox2, but also provides zooming, faster loading, and swipe actions, as well as clicking and arrow key pressing. This is a definite benefit for viewing my site on mobile.
 
 The author of PhotoSwipe, @dimsemenov, has been working on a new v5 beta version of PhotoSwipe, which is [documented here](https://photoswipe.com/v5/docs/getting-started/). Although the v5 documentation isn't fully fleshed out (the version is still in beta after all) I still found PhotoSwipe v5 simple enough to set up.
 
-I started with an `activate_photoswipe.js` file:
+I started with an `assets/js/activate_photoswipe.js` file:
 
 ```javascript
 import PhotoSwipeLightbox from './photoswipe-lightbox.esm.min.js'
@@ -37,11 +37,11 @@ And then I modified my `_includes/photo.html` file to allow both Lightbox2 photo
   <a class="photoswipe photo" href="{{ include.url }}" target="_blank" data-pswp-width="{{ include.full_width }}" data-pswp-height="{{ include.full_height }}">
 {% endif %}
 
-    <img class="image" src="{{ include.url }}" width="{{ include.thumb_width }}" height="{{ thumb_height }}" alt="{{ include.alt }}">
+    <img class="image" src="{{ include.url }}" width="{{ include.thumb_width }}" height="{{ include.thumb_height }}" alt="{{ include.alt }}">
   </a>{% endraw %}
 ```
 
-This way, when we call a photo, we can pass in a `type` (only required if using Lightbox2). And if we're using Lightbox2, then create a Lightbox2 photo, else create a PhotoSwipe photo:
+This way, when we call a photo, we can pass in a `type` (only required if using Lightbox2). And if we're using Lightbox2, then create a Lightbox2 photo, else create a PhotoSwipe photo. Here's how I would call the `_includes` file:
 
 ```html
 <!-- Lightbox2 -->
@@ -67,7 +67,7 @@ Then, in my `_layouts/default.html` file, I needed to initialize PhotoSwipe:
 <script src="/assets/js/activate_photoswipe.js" type="module"></script>
 ```
 
-Lastly, I needed to download three files from the [`dist`](https://github.com/dimsemenov/PhotoSwipe/tree/v5-beta/dist) directory: `photoswipe.css`, `photoswipe-lightbox.esm.min.js`, and `photoswipe.esm.min.js`.
+Lastly, I needed to download three files from the [`dist`](https://github.com/dimsemenov/PhotoSwipe/tree/v5-beta/dist) directory: `photoswipe.css`, `photoswipe-lightbox.esm.min.js`, and `photoswipe.esm.min.js`. I placed these in `assets/css` and `assets/js` according to the file types.
 
 And voilà. PhotoSwipe works! Feel free to compare a Lightbox2 example (left) with a PhotoSwipe example (right):
 
@@ -106,7 +106,7 @@ But the real benefit to PhotoSwipe is visible when you have a gallery of images.
   %}
 </div>
 
-The images are slow to load, and although you can navigate by clicking a photo and using arrow keys on keyboard, a mobile user cannot swipe. Furthermore, if you click in _slightly_ the wrong place, a Lightbox2 gallery will exit, making it a tedious tool to use as a viewer.
+The images are slow to load, and although you can navigate by clicking a photo and using arrow keys on keyboard, a mobile user cannot swipe. Furthermore, if you click in _slightly_ the wrong place, a Lightbox2 gallery will exit, making it a tedious viewing experience.
 
 But, take a look at the same gallery through PhotoSwipe:
 
@@ -134,7 +134,7 @@ Now with only those few changes, PhotoSwipe v5 is completely set up, and I can b
 
 But even after all that, you'll notice that there's something huge missing from PhotoSwipe: captions. All of my Lightbox2 photos had captions. Luckily, PhotoSwipe v5 has some detailed documentation on how to enable captions.
 
-First, I added Javascript to `activate_photoswipe.js`. The entire file came out like this:
+First, I added Javascript to `assets/js/activate_photoswipe.js`. Based on the documentation provided, and after some fiddling on my part, the entire file came out like this:
 
 ```javascript
 import PhotoSwipeLightbox from './photoswipe-lightbox.esm.min.js'
@@ -181,6 +181,7 @@ lightbox.on('uiRegister', function () {
     }
   })
 })
+
 lightbox.init()
 ```
 
@@ -204,7 +205,7 @@ What this logic does is when we click on a photo, if the `caption` class is eith
   %}
 </div>
 
-Throughout my PhotoSwipe experimenting, there were several other changes I made to the core files mentioned. In order to avoid attempting to summarize with English language, I'll just provide links to the completed code:
+Throughout my PhotoSwipe experimenting, there were several other changes I made to the core files mentioned. These were in order to implement nested galleries, caption and "alt" interchangeability, optional thumb photo widths and heights, etc. In order to avoid attempting to summarize further with English language, I'll just provide links to the completed code:
 
 * [Documentation about adding PhotoSwipe and Lightbox2]({{ site.author_profiles.github }}/{{ site.github_repo }}/blob/b6661ecdf093cf79dbb755f15eabab1740c75390/.github/contributing.md#images)
 * [`assets/js/activate_photoswipe.js`]({{ site.author_profiles.github }}/{{ site.github_repo }}/blob/b6661ecdf093cf79dbb755f15eabab1740c75390/assets/js/activate_photoswipe.js)

--- a/_blog_posts/turning-lightbox2-into-photoswipe.md
+++ b/_blog_posts/turning-lightbox2-into-photoswipe.md
@@ -79,7 +79,7 @@ And voilà. PhotoSwipe works! Feel free to compare a Lightbox2 example (left) wi
   %}
   {% include elements/photo.html
       url="https://i.imgur.com/lyWrj3r.jpeg"
-      thumb_height="127"
+      thumb_height="127" alt="Adorable creature"
       full_width="600" full_height="380"
   %}
 </div>

--- a/_blog_posts/turning-lightbox2-into-photoswipe.md
+++ b/_blog_posts/turning-lightbox2-into-photoswipe.md
@@ -1,0 +1,214 @@
+---
+layout: post
+title: Turning Lightbox2 into PhotoSwipe
+tags: [ tech, jekyll ]
+permalink: /blog/posts/turning-lightbox2-into-photoswipe/
+draft: true
+---
+
+Last August, I made a big push to add better photo functionality to my website. I added [Lightbox2](https://lokeshdhakar.com/projects/lightbox2/), by @lokesh, to my site. In a [previous blog post](/blog/posts/adding-lightbox-to-a-jekyll-website/), I referenced it as plain Lightbox. It turns out that Lightbox2 is built upon Lightbox JS, by the same author. But technically, I incorporated Lightbox2 to my site.
+
+But recently, upon the advice of an old schoolmate, I came across [PhotoSwipe](https://photoswipe.com/). PhotoSwipe provides similar abilities to Lightbox2, but also provides zooming, faster loading, and swipe actions, as well as clicking and arrow key pressing. This is a definite benefit for viewing the site on mobile.
+
+The author of PhotoSwipe, @dimsemenov, has been working on a new v5 beta version of PhotoSwipe, which is [documented here](https://photoswipe.com/v5/docs/getting-started/). Although the v5 documentation isn't fully fleshed out (the version is still in beta after all) I still found PhotoSwipe v5 simple enough to set up.
+
+I started with an `activate_photoswipe.js` file:
+
+```javascript
+import PhotoSwipeLightbox from './photoswipe-lightbox.esm.min.js'
+
+const options = {
+  gallerySelector: '.photoswipe-gallery',
+  childSelector: '.photoswipe',
+  pswpModule: '/assets/js/photoswipe.esm.min.js',
+  pswpCSS: '/assets/css/photoswipe.min.css'
+}
+
+const lightbox = new PhotoSwipeLightbox(options)
+lightbox.init()
+```
+
+And then I modified my `_includes/photo.html` file to allow both Lightbox2 photos and PhotoSwipe:
+
+```html
+{% raw %}{% if include.type == "lightbox2" %}
+  <a class="lightbox2 photo" href="{{ include.url }}" data-lightbox="{{ include.lightbox_gallery }}" title="{{ include.caption }}">
+{% else %}
+  <a class="photoswipe photo" href="{{ include.url }}" target="_blank" data-pswp-width="{{ include.full_width }}" data-pswp-height="{{ include.full_height }}">
+{% endif %}
+
+    <img class="image" src="{{ include.url }}" width="{{ include.thumb_width }}" height="{{ thumb_height }}" alt="{{ include.alt }}">
+  </a>{% endraw %}
+```
+
+This way, when we call a photo, we can pass in a `type` (only required if using Lightbox2). And if we're using Lightbox2, then create a Lightbox2 photo, else create a PhotoSwipe photo:
+
+```html
+<!-- Lightbox2 -->
+{% raw %}{% include elements/photo.html
+   url="https://i.imgur.com/lyWrj3r.jpeg"
+   thumb_width="200" caption="Adorable creature" alt="Adorable creature"
+   type="lightbox2" lightbox_gallery="PHOTO1"
+%}{% endraw %}
+
+<!-- PhotoSwipe -->
+{% raw %}<div class="photoswipe-gallery">
+  {% include elements/photo.html
+     url="https://i.imgur.com/lyWrj3r.jpeg"
+     thumb_width="200" alt="Adorable creature"
+     full_width="600" full_height="380"
+  %}
+</div>{% endraw %}
+```
+
+Then, in my `_layouts/default.html` file, I needed to initialize PhotoSwipe:
+
+```html
+<script src="/assets/js/activate_photoswipe.js" type="module"></script>
+```
+
+Lastly, I needed to download three files from the [`dist`](https://github.com/dimsemenov/PhotoSwipe/tree/v5-beta/dist) directory: `photoswipe.css`, `photoswipe-lightbox.esm.min.js`, and `photoswipe.esm.min.js`.
+
+And voilà. PhotoSwipe works! Feel free to compare a Lightbox2 example (left) with a PhotoSwipe example (right):
+
+<div class="text-center photoswipe-gallery">
+  {% include elements/photo.html
+      url="https://i.imgur.com/lyWrj3r.jpeg"
+      thumb_height="127" caption="Adorable creature"
+      type="lightbox2" lightbox_gallery="PHOTO1"
+  %}
+  {% include elements/photo.html
+      url="https://i.imgur.com/lyWrj3r.jpeg"
+      thumb_height="127"
+      full_width="600" full_height="380"
+  %}
+</div>
+
+As you can see, the two are very similar. However, PhotoSwipe is slightly faster to load, and I've found that Lightbox2 is touchy to use (aka not a consistent user experience).
+
+But the real benefit to PhotoSwipe is visible when you have a gallery of images. Take a look at this Lightbox2 gallery below:
+
+<div class="text-center">
+  {% include elements/photo.html
+      url="https://i.imgur.com/lyWrj3r.jpeg"
+      thumb_height="127" caption="Original adorable creature"
+      type="lightbox2" lightbox_gallery="lightbox-gallery"
+  %}
+  {% include elements/photo.html
+      url="https://i.imgur.com/ZusTRJ9.jpg"
+      thumb_height="127" caption="Kitten cuddling a puppy"
+      type="lightbox2" lightbox_gallery="lightbox-gallery"
+  %}
+  {% include elements/photo.html
+      url="https://i.imgur.com/NuhaJCb.jpeg"
+      thumb_height="127" caption="Puppy popping bubbles"
+      type="lightbox2" lightbox_gallery="lightbox-gallery"
+  %}
+</div>
+
+The images are slow to load, and although you can navigate by clicking a photo and using arrow keys on keyboard, a mobile user cannot swipe. Furthermore, if you click in _slightly_ the wrong place, a Lightbox2 gallery will exit, making it a tedious tool to use as a viewer.
+
+But, take a look at the same gallery through PhotoSwipe:
+
+<div class="text-center photoswipe-gallery">
+  {% include elements/photo.html
+      url="https://i.imgur.com/lyWrj3r.jpeg"
+      thumb_height="127" alt="Original adorable creature"
+      full_width="600" full_height="380"
+  %}
+  {% include elements/photo.html
+      url="https://i.imgur.com/ZusTRJ9.jpg"
+      thumb_height="127" alt="Kitten cuddling a puppy"
+      full_width="600" full_height="450"
+  %}
+  {% include elements/photo.html
+      url="https://i.imgur.com/NuhaJCb.jpeg"
+      thumb_height="127" alt="Puppy popping bubbles"
+      full_width="530" full_height="424"
+  %}
+</div>
+
+Hopefully the images are loading faster, you can swipe through photos (helpful when you're a mobile user), and zoom may even be available (I've noticed zoom is only available on some images, and the images in this demo may not offer zoom... perhaps future versions of PhotoSwipe may increase zoom capabilities).
+
+Now with only those few changes, PhotoSwipe v5 is completely set up, and I can begin transitioning my Lightbox2 photos to PhotoSwipe. The most irritating process of that transition was that PhotoSwipe requires the HTML to specifically provide the width and height of each picture by pixel. So, I needed to look at each picture individually, and look up its width and height. Good thing I only had 194 pictures shown throughout my entire site&nbsp;🥴.
+
+But even after all that, you'll notice that there's something huge missing from PhotoSwipe: captions. All of my Lightbox2 photos had captions. Luckily, PhotoSwipe v5 has some detailed documentation on how to enable captions.
+
+First, I added Javascript to `activate_photoswipe.js`. The entire file came out like this:
+
+```javascript
+import PhotoSwipeLightbox from './photoswipe-lightbox.esm.min.js'
+
+const options = {
+  gallerySelector: '.photoswipe-gallery',
+  childSelector: '.photoswipe',
+  pswpModule: '/assets/js/photoswipe.esm.min.js',
+  pswpCSS: '/assets/css/photoswipe.min.css'
+}
+
+const lightbox = new PhotoSwipeLightbox(options)
+
+lightbox.on('uiRegister', function () {
+  lightbox.pswp.ui.registerElement({
+    name: 'custom-caption',
+    order: 9,
+    isButton: false,
+    appendTo: 'root',
+    html: 'Caption Text',
+    onInit: (el, pswp) => {
+      lightbox.pswp.on('change', () => {
+        const currentSlideElement = lightbox.pswp.currSlide.data.element
+        const hiddenCaption = currentSlideElement.querySelector('.caption')
+        const customCaptionElements = document.getElementsByClassName('pswp__custom-caption')
+        let captionHTML = ''
+
+        if (hiddenCaption === '' || hiddenCaption === null) {
+          for (let counter = 0; counter < customCaptionElements.length; counter++) {
+            customCaptionElements[counter].classList.add('invisible')
+          }
+        } else {
+          for (let counter = 0; counter < customCaptionElements.length; counter++) {
+            customCaptionElements[counter].classList.remove('invisible')
+          }
+
+          if (currentSlideElement) {
+            captionHTML = hiddenCaption.innerHTML
+          }
+        }
+
+        el.innerHTML = captionHTML
+      })
+    }
+  })
+})
+lightbox.init()
+```
+
+What this logic does is when we click on a photo, if the `caption` class is either missing or empty, then it'll turn all PhotoSwipe captions "invisible" by adding the `invisible` class. If the `caption` class exists and the caption contains words, then it'll remove any `invisible` class, and set the caption text to match the HTML text provided. This way, photos can have optional captions, and if the caption doesn't exist, then the spot for a caption will disappear. If an ["alt"](https://www.w3schools.com/tags/att_img_alt.asp) is provided, then use that as alternative text, but don't automatically use it as a caption. If _only_ a caption is given, then we can _also_ use that as alternative text. See a gallery example below:
+
+<div class="text-center photoswipe-gallery">
+  {% include elements/photo.html
+      url="https://i.imgur.com/lyWrj3r.jpeg"
+      thumb_height="127" caption="Original adorable creature"
+      full_width="600" full_height="380"
+  %}
+  {% include elements/photo.html
+      url="https://i.imgur.com/ZusTRJ9.jpg"
+      thumb_height="127" alt="Kitten cuddling a puppy"
+      full_width="600" full_height="450"
+  %}
+  {% include elements/photo.html
+      url="https://i.imgur.com/NuhaJCb.jpeg"
+      thumb_height="127" caption="Puppy popping bubbles"
+      full_width="530" full_height="424"
+  %}
+</div>
+
+Throughout my PhotoSwipe experimenting, there were several other changes I made to the core files mentioned. In order to avoid attempting to summarize with English language, I'll just provide links to the completed code:
+
+* [Documentation about adding PhotoSwipe and Lightbox2]({{ site.author_profiles.github }}/{{ site.github_repo }}/blob/b6661ecdf093cf79dbb755f15eabab1740c75390/.github/contributing.md#images)
+* [`assets/js/activate_photoswipe.js`]({{ site.author_profiles.github }}/{{ site.github_repo }}/blob/b6661ecdf093cf79dbb755f15eabab1740c75390/assets/js/activate_photoswipe.js)
+* [`_includes/elements/photo.html`]({{ site.author_profiles.github }}/{{ site.github_repo }}/blob/b6661ecdf093cf79dbb755f15eabab1740c75390/_includes/elements/photo.html)
+* [`_layouts/default.html`]({{ site.author_profiles.github }}/{{ site.github_repo }}/blob/b6661ecdf093cf79dbb755f15eabab1740c75390/_layouts/default.html#L58-L64)
+
+Please feel free to reach out to me for additional information or questions you have about implementing PhotoSwipe v5. With PhotoSwipe, I'm confident that viewing images on my website will be a much better experience for both me and my viewers going forward.

--- a/_includes/blog/post_categorization.html
+++ b/_includes/blog/post_categorization.html
@@ -3,9 +3,7 @@
     <i class="post-categorization-icon" data-feather="tag"></i>
 
     {% for tag in tags_to_show %}
-      <a href="/blog/{{ tag }}/">
-        {{ tag }}
-      </a>
+      <a href="/blog/{{ tag }}/">{{ tag }}</a>
 
       {% unless tag == tags_to_show.last %}
         |


### PR DESCRIPTION
## Changes

Add a new blog post about turning all photos using Lightbox2 to PhotoSwipe v5.

This PR also addresses a bug where linking to multiple tags on a single blog post accidentally adds a space that is underlined when hovering over any tags that aren't last.

## Related Pull Requests and Issues

> If applicable, a list of related pull requests and issues:
>
> * Issue URL link
> * Pull Request URL link

## Additional Context

> Add any other context about the problem here.

## PR Scheduler

> If you'd like to use the PR Scheduler, then add a comment to this pull request where the date/time is written in UTC and the pull request will merged and deployed at the date/time provided. The comment should look like this:
>
> ```
> # example (May 18, 2020 at 17:58 UTC):
> @prscheduler 2020-05-18 17:58
>
> @prscheduler YYYY-MM-DD HH:MM
> ```
