### PR TITLE
Stop underlining even more buttons

### DIFF
--- a/_layouts/contact.html
+++ b/_layouts/contact.html
@@ -47,7 +47,7 @@ layout: default
       data-expired-callback="recaptchaExpiredCallback" data-sitekey="6Ld6_CcaAAAAAOXP4F6Ze2M5mbeqFRSEN9dlUecn"
     ></div>
 
-    <button type="submit" id="submitButton" disabled class="btn btn-outline-secondary form-button">
+    <button type="submit" id="submitButton" disabled class="btn btn-outline-secondary form-button button-text">
       Send Message
     </button>
   </form>
@@ -58,7 +58,7 @@ layout: default
   Thank you for your message! I will get back to you as soon as I can.
 
   <div class="text-center container form-thank-you-button">
-    <a href="/" class="btn btn-lg btn-outline-secondary">Back to Homepage</a>
+    <a href="/" class="btn btn-lg btn-outline-secondary button-text">Back to Homepage</a>
   </div>
 </div>
 

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -49,7 +49,7 @@ layout: default
 
       {% if page.comments != false and jekyll.environment == "production" %}
         <div class="text-center margin-bottom-1">
-          <button id="show-comments-button" class="btn btn-lg btn-outline-secondary">
+          <button id="show-comments-button" class="btn btn-lg btn-outline-secondary button-text">
             Load Comments
           </button>
 


### PR DESCRIPTION
## Changes

There's a few more buttons that are underlining on hover, and none of them should. So, add the `button-text` class to those buttons.

## Related Pull Requests and Issues

* https://github.com/emmahsax/emmahsax.github.io/pull/407
* https://github.com/emmahsax/emmahsax.github.io/pull/400

## Additional Context

> Add any other context about the problem here.

## PR Scheduler

> If you'd like to use the PR Scheduler, then add a comment to this pull request where the date/time is written in UTC and the pull request will merged and deployed at the date/time provided. The comment should look like this:
>
> ```
> # Example (May 18, 2020 at 17:58 UTC):
> @prscheduler 2020-05-18 17:58
>
> @prscheduler YYYY-MM-DD HH:MM
> ```
